### PR TITLE
ci(workflows): add CI, security, release, and supply-chain pipeline

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,51 @@
+# Codecov configuration. Validated with `curl --data-binary @.github/codecov.yml https://codecov.io/validate`.
+codecov:
+  require_ci_to_pass: true
+  notify:
+    wait_for_ci: true
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...95"
+  status:
+    project:
+      default: false
+      core:
+        # The library is the part of the project we care about. Aim for >80%
+        # statement coverage; PRs that drop coverage by more than 1pp fail.
+        target: 80%
+        threshold: 1%
+        flags:
+          - core
+        paths:
+          - core/
+        if_ci_failed: error
+    patch:
+      default: false
+      core:
+        target: 80%
+        flags:
+          - core
+        paths:
+          - core/
+        if_ci_failed: error
+
+flags:
+  core:
+    paths:
+      - core/
+    carryforward: false
+
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default
+  require_changes: false
+
+ignore:
+  - "cmd/**"
+  - "examples/**"
+  - "docs/**"
+  - "**/testdata/**"
+  - "**/*_test.go"
+  - "**/mocks/**"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   GO_VERSION: "1.26"
@@ -36,6 +36,7 @@ jobs:
         run: |
           if find . -name '*.go' \
               -not -path './.*' \
+              -not -path './vendor/*' \
               -not -path '*/testdata/*' \
               -print -quit | grep -q .; then
             echo "has-source=true" >> "$GITHUB_OUTPUT"
@@ -66,9 +67,10 @@ jobs:
 
       - name: go mod tidy -diff
         run: |
-          go mod tidy -diff
-          if [ -n "$(go mod tidy -diff)" ]; then
+          diff=$(go mod tidy -diff)
+          if [ -n "$diff" ]; then
             echo "go.mod / go.sum drift detected; run 'go mod tidy' and commit."
+            echo "$diff"
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,189 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GO_VERSION: "1.26"
+
+jobs:
+  detect:
+    name: detect go source
+    runs-on: ubuntu-latest
+    outputs:
+      has-source: ${{ steps.detect.outputs.has-source }}
+    steps:
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Detect Go source
+        id: detect
+        shell: bash
+        run: |
+          if find . -name '*.go' \
+              -not -path './.*' \
+              -not -path '*/testdata/*' \
+              -print -quit | grep -q .; then
+            echo "has-source=true" >> "$GITHUB_OUTPUT"
+            echo "Go source detected — full CI will run."
+          else
+            echo "has-source=false" >> "$GITHUB_OUTPUT"
+            echo "No Go source yet — lint/test/build steps will be skipped."
+          fi
+
+  lint:
+    name: lint
+    needs: detect
+    runs-on: ubuntu-latest
+    steps:
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: go mod verify
+        run: go mod verify
+
+      - name: go mod tidy -diff
+        run: |
+          go mod tidy -diff
+          if [ -n "$(go mod tidy -diff)" ]; then
+            echo "go.mod / go.sum drift detected; run 'go mod tidy' and commit."
+            exit 1
+          fi
+
+      - name: gofmt
+        if: needs.detect.outputs.has-source == 'true'
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "Unformatted files:"
+            echo "$unformatted"
+            echo "Run 'go tool goimports -w -local github.com/plexara/plexara-agents .' and commit."
+            exit 1
+          fi
+
+      - name: go vet
+        if: needs.detect.outputs.has-source == 'true'
+        run: go vet ./...
+
+      - name: golangci-lint config verify
+        run: go tool golangci-lint config verify
+
+      - name: golangci-lint
+        if: needs.detect.outputs.has-source == 'true'
+        run: go tool golangci-lint run ./...
+
+  test:
+    name: test (${{ matrix.os }})
+    needs: detect
+    if: needs.detect.outputs.has-source == 'true'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Test (race + shuffle + coverage)
+        run: |
+          go test -race -shuffle=on -count=1 \
+            -covermode=atomic \
+            -coverprofile=coverage.out \
+            ./...
+
+      - name: Upload coverage to Codecov
+        if: matrix.os == 'ubuntu-latest'
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.out
+          flags: core
+          fail_ci_if_error: true
+
+  build:
+    name: build (${{ matrix.goos }}/${{ matrix.goarch }})
+    needs: detect
+    if: needs.detect.outputs.has-source == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+          - goos: windows
+            goarch: amd64
+    env:
+      CGO_ENABLED: "0"
+      GOOS: ${{ matrix.goos }}
+      GOARCH: ${{ matrix.goarch }}
+    steps:
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Build
+        run: go build -trimpath ./...
+
+  ci-pass:
+    name: ci pass
+    needs: [lint, test, build]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate
+        run: |
+          if [ "${{ needs.lint.result }}" != "success" ]; then
+            echo "lint failed"; exit 1
+          fi
+          if [ "${{ needs.test.result }}" != "success" ] && [ "${{ needs.test.result }}" != "skipped" ]; then
+            echo "test failed"; exit 1
+          fi
+          if [ "${{ needs.build.result }}" != "success" ] && [ "${{ needs.build.result }}" != "skipped" ]; then
+            echo "build failed"; exit 1
+          fi
+          echo "ci passed"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,63 @@
+name: codeql
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 7 * * 1"  # weekly Monday 07:00 UTC
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: analyze go
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    steps:
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.26"
+          cache: true
+
+      - name: Detect Go source
+        id: detect
+        shell: bash
+        run: |
+          if find . -name '*.go' -not -path './.*' -not -path '*/testdata/*' -print -quit | grep -q .; then
+            echo "has-source=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-source=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Initialize CodeQL
+        if: steps.detect.outputs.has-source == 'true'
+        uses: github/codeql-action/init@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3.35.3
+        with:
+          languages: go
+          queries: security-extended,security-and-quality
+
+      - name: Autobuild
+        if: steps.detect.outputs.has-source == 'true'
+        uses: github/codeql-action/autobuild@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3.35.3
+
+      - name: Analyze
+        if: steps.detect.outputs.has-source == 'true'
+        uses: github/codeql-action/analyze@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3.35.3
+        with:
+          category: "/language:go"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,8 +12,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: codeql-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   analyze:
@@ -39,7 +39,7 @@ jobs:
         id: detect
         shell: bash
         run: |
-          if find . -name '*.go' -not -path './.*' -not -path '*/testdata/*' -print -quit | grep -q .; then
+          if find . -name '*.go' -not -path './.*' -not -path './vendor/*' -not -path '*/testdata/*' -print -quit | grep -q .; then
             echo "has-source=true" >> "$GITHUB_OUTPUT"
           else
             echo "has-source=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,37 @@
+name: dependency-review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    name: review
+    runs-on: ubuntu-latest
+    steps:
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure
+          # License allowlist mirrors §14.7 of the bootstrap spec.
+          allow-licenses: >-
+            Apache-2.0,
+            BSD-2-Clause,
+            BSD-3-Clause,
+            ISC,
+            MIT,
+            MPL-2.0,
+            Unlicense,
+            CC0-1.0,
+            Zlib,
+            BSD-2-Clause-Patent

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -37,26 +37,27 @@ jobs:
         shell: bash
         run: |
           # Emit one JSON entry per (package, FuzzXxx) pair so the matrix can fan out.
-          targets=$(go test -list 'Fuzz.*' ./... 2>/dev/null \
-            | awk '
-                /^ok / || /^---/ { next }
-                /^FAIL/ { next }
-                /^Fuzz/ { fuzz[NR]=$0; pkgline=NR; next }
-                /^[a-zA-Z]/ { pkg=$0 }
-                END {
-                  for (n in fuzz) {
-                    print pkg "::" fuzz[n]
-                  }
-                }' \
-            | jq -R -s -c 'split("\n") | map(select(length > 0))')
-          if [ -z "$targets" ] || [ "$targets" = "[]" ]; then
+          # `go test -list` prints fuzz names *before* the trailing "ok <pkg>" line,
+          # so we iterate per-package via `go list` rather than parsing the combined
+          # stream.
+          targets=()
+          while IFS= read -r pkg; do
+            [ -z "$pkg" ] && continue
+            while IFS= read -r fuzz; do
+              [ -z "$fuzz" ] && continue
+              targets+=("$pkg::$fuzz")
+            done < <(go test -list 'Fuzz.*' "$pkg" 2>/dev/null | awk '/^Fuzz/')
+          done < <(go list ./... 2>/dev/null)
+
+          if [ ${#targets[@]} -eq 0 ]; then
             echo "targets=[]" >> "$GITHUB_OUTPUT"
             echo "has-targets=false" >> "$GITHUB_OUTPUT"
             echo "No fuzz targets discovered."
           else
-            echo "targets=$targets" >> "$GITHUB_OUTPUT"
+            json=$(printf '%s\n' "${targets[@]}" | jq -R . | jq -s -c .)
+            echo "targets=$json" >> "$GITHUB_OUTPUT"
             echo "has-targets=true" >> "$GITHUB_OUTPUT"
-            echo "Discovered: $targets"
+            echo "Discovered: $json"
           fi
 
   fuzz:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,101 @@
+name: fuzz
+
+on:
+  schedule:
+    - cron: "0 4 * * *"  # nightly 04:00 UTC
+  workflow_dispatch:
+    inputs:
+      duration:
+        description: "Per-target fuzz duration (e.g. 5m, 30s)"
+        required: false
+        default: "5m"
+
+permissions:
+  contents: read
+
+jobs:
+  detect:
+    name: detect fuzz targets
+    runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.targets.outputs.targets }}
+      has-targets: ${{ steps.targets.outputs.has-targets }}
+    steps:
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.26"
+          cache: true
+
+      - name: Discover Fuzz targets
+        id: targets
+        shell: bash
+        run: |
+          # Emit one JSON entry per (package, FuzzXxx) pair so the matrix can fan out.
+          targets=$(go test -list 'Fuzz.*' ./... 2>/dev/null \
+            | awk '
+                /^ok / || /^---/ { next }
+                /^FAIL/ { next }
+                /^Fuzz/ { fuzz[NR]=$0; pkgline=NR; next }
+                /^[a-zA-Z]/ { pkg=$0 }
+                END {
+                  for (n in fuzz) {
+                    print pkg "::" fuzz[n]
+                  }
+                }' \
+            | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          if [ -z "$targets" ] || [ "$targets" = "[]" ]; then
+            echo "targets=[]" >> "$GITHUB_OUTPUT"
+            echo "has-targets=false" >> "$GITHUB_OUTPUT"
+            echo "No fuzz targets discovered."
+          else
+            echo "targets=$targets" >> "$GITHUB_OUTPUT"
+            echo "has-targets=true" >> "$GITHUB_OUTPUT"
+            echo "Discovered: $targets"
+          fi
+
+  fuzz:
+    name: fuzz ${{ matrix.target }}
+    needs: detect
+    if: needs.detect.outputs.has-targets == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJson(needs.detect.outputs.targets) }}
+    steps:
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.26"
+          cache: true
+
+      - name: Fuzz
+        shell: bash
+        run: |
+          duration="${{ inputs.duration }}"
+          : "${duration:=5m}"
+          pkg="${{ matrix.target }}"
+          fuzz_pkg="${pkg%%::*}"
+          fuzz_name="${pkg##*::}"
+          echo "Fuzzing $fuzz_name in $fuzz_pkg for $duration"
+          go test "$fuzz_pkg" -run='^$' -fuzz="^${fuzz_name}\$" -fuzztime="$duration"
+
+      - name: Upload corpus on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fuzz-corpus-${{ matrix.target }}
+          path: testdata/fuzz/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,40 @@
+name: pr-title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  semantic:
+    name: conventional commit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            chore
+            refactor
+            test
+            perf
+            ci
+            build
+            revert
+          requireScope: false
+          subjectPattern: ^[A-Za-z0-9].+$
+          subjectPatternError: |
+            The PR title subject "{subject}" must start with an alphanumeric character.
+          # Conventional Commits message format is "<type>(<scope>): <subject>".
+          # Examples:
+          #   feat(core/loop): add MaxSteps cap to agent loop
+          #   fix(core/provider): buffer tool-call deltas until finish_reason
+          #   docs(adrs): add ADR-0001 for tool directive decision

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -24,6 +24,7 @@ jobs:
             docs
             chore
             refactor
+            style
             test
             perf
             ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,15 +13,20 @@ on:
 permissions:
   contents: read
 
+env:
+  GO_VERSION: "1.26"
+
 jobs:
   release:
     name: goreleaser
     runs-on: ubuntu-latest
     permissions:
       contents: write          # publish release + assets
-      packages: write          # ghcr (container images, deferred per spec §14.8)
       id-token: write          # cosign keyless signing + attest-build-provenance via Sigstore OIDC
       attestations: write      # SLSA provenance attestations
+      # Note: packages: write is intentionally omitted. Container image
+      # publishing to ghcr is deferred per spec §14.8; restore this scope
+      # when that work lands.
     steps:
       - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
         with:
@@ -33,7 +38,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26"
+          go-version: ${{ env.GO_VERSION }}
           cache: true
 
       - name: Install Cosign

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,74 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (must already exist, e.g. v0.1.0)"
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: goreleaser
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write          # publish release + assets
+      packages: write          # ghcr (container images, deferred per spec §14.8)
+      id-token: write          # cosign keyless signing + attest-build-provenance via Sigstore OIDC
+      attestations: write      # SLSA provenance attestations
+    steps:
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0       # GoReleaser needs full history for changelog
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.26"
+          cache: true
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+
+      - name: Install Syft (SBOM generator)
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+
+      - name: GoReleaser
+        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Optional: HOMEBREW_TAP_GITHUB_TOKEN authorizes pushes to plexara/homebrew-tap.
+          # Absent secret -> the brew step in .goreleaser.yaml is skipped (skip_upload: auto).
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+
+      - name: Generate SLSA build provenance
+        # Produces SLSA v1 in-toto provenance, signed via Sigstore (keyless).
+        # The attestation is associated with the release artifacts and verifiable
+        # with `gh attestation verify`.
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: |
+            dist/*.tar.gz
+            dist/*.zip
+            dist/*.sbom.*
+
+      - name: Upload SBOMs as workflow artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sboms
+          path: dist/*.sbom.*
+          if-no-files-found: ignore
+          retention-days: 30

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,52 @@
+name: scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "0 8 * * 1"  # weekly Monday 08:00 UTC
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+    steps:
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # SCORECARD_READ_TOKEN is optional. When absent, the Branch-Protection
+          # check returns "?" but other checks still run. To populate it, create a
+          # fine-grained PAT with Administration: Read on this repository and add
+          # it as the SCORECARD_READ_TOKEN secret.
+          repo_token: ${{ secrets.SCORECARD_READ_TOKEN || secrets.GITHUB_TOKEN }}
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to security tab
+        uses: github/codeql-action/upload-sarif@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3.35.3
+        with:
+          sarif_file: results.sarif
+          category: scorecard

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,7 +7,8 @@ on:
   push:
     branches: [main]
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   analysis:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,144 @@
+name: security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"  # weekly Monday 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GO_VERSION: "1.26"
+
+jobs:
+  detect:
+    name: detect go source
+    runs-on: ubuntu-latest
+    outputs:
+      has-source: ${{ steps.detect.outputs.has-source }}
+    steps:
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - id: detect
+        shell: bash
+        run: |
+          if find . -name '*.go' -not -path './.*' -not -path '*/testdata/*' -print -quit | grep -q .; then
+            echo "has-source=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-source=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  gosec:
+    name: gosec
+    needs: detect
+    if: needs.detect.outputs.has-source == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: securego/gosec@4a3bd8af174872c778439083ded7adbf3747e770 # v2.26.1
+        with:
+          args: -fmt sarif -out gosec.sarif -no-fail ./...
+
+      - uses: github/codeql-action/upload-sarif@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3.35.3
+        with:
+          sarif_file: gosec.sarif
+          category: gosec
+
+  govulncheck:
+    name: govulncheck
+    needs: detect
+    runs-on: ubuntu-latest
+    steps:
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: govulncheck
+        run: go tool govulncheck ./...
+
+  semgrep:
+    name: semgrep
+    needs: detect
+    if: needs.detect.outputs.has-source == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    container:
+      # semgrep/semgrep:1.161.0 (multi-arch manifest list digest)
+      image: semgrep/semgrep@sha256:326e5f41cc972bb423b764a14febbb62bbad29ee1c01820805d077dd868fea48
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Semgrep
+        run: |
+          semgrep \
+            --config=p/security-audit \
+            --config=p/secrets \
+            --config=p/golang \
+            --config=p/owasp-top-ten \
+            --sarif --output=semgrep.sarif \
+            --error \
+            .
+
+      - uses: github/codeql-action/upload-sarif@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3.35.3
+        if: always()
+        with:
+          sarif_file: semgrep.sarif
+          category: semgrep
+
+  trivy:
+    name: trivy fs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: sarif
+          output: trivy.sarif
+          ignore-unfixed: true
+          exit-code: "0"  # report findings; do not fail the build directly. SARIF gates are visible via security tab.
+
+      - uses: github/codeql-action/upload-sarif@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3.35.3
+        if: always()
+        with:
+          sarif_file: trivy.sarif
+          category: trivy

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,8 +13,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: security-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   GO_VERSION: "1.26"
@@ -35,7 +35,7 @@ jobs:
       - id: detect
         shell: bash
         run: |
-          if find . -name '*.go' -not -path './.*' -not -path '*/testdata/*' -print -quit | grep -q .; then
+          if find . -name '*.go' -not -path './.*' -not -path './vendor/*' -not -path '*/testdata/*' -print -quit | grep -q .; then
             echo "has-source=true" >> "$GITHUB_OUTPUT"
           else
             echo "has-source=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -68,6 +68,10 @@ jobs:
   govulncheck:
     name: govulncheck
     needs: detect
+    # govulncheck scans Go source; it returns "no packages matched the provided
+    # patterns" and exits 1 on an empty source tree. Gate on detect.has-source
+    # so the job is a no-op until phase 3 (#4) lands the first .go file.
+    if: needs.detect.outputs.has-source == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,152 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+version: 2
+
+project_name: plexara-agents
+
+before:
+  hooks:
+    - go mod tidy
+    - go mod verify
+
+builds:
+  - id: ask
+    main: ./cmd/ask
+    binary: ask
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X main.version={{ .Version }}
+      - -X main.commit={{ .Commit }}
+      - -X main.date={{ .CommitDate }}
+      - -X main.builtBy=goreleaser
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    mod_timestamp: "{{ .CommitTimestamp }}"
+
+archives:
+  - id: default
+    ids: [ask]
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+    formats: [tar.gz]
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+    files:
+      - LICENSE
+      - README.md
+      - SECURITY.md
+
+checksum:
+  name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"
+  algorithm: sha256
+
+signs:
+  - cmd: cosign
+    artifacts: checksum
+    output: true
+    certificate: "${artifact}.pem"
+    args:
+      - sign-blob
+      - --yes
+      - --output-certificate=${certificate}
+      - --output-signature=${signature}
+      - "${artifact}"
+
+sboms:
+  - id: cyclonedx
+    artifacts: archive
+    documents:
+      - "{{ .ArtifactName }}.cyclonedx.sbom.json"
+    cmd: syft
+    args: ["${artifact}", "--output", "cyclonedx-json={{ .Document }}"]
+  - id: spdx
+    artifacts: archive
+    documents:
+      - "{{ .ArtifactName }}.spdx.sbom.json"
+    cmd: syft
+    args: ["${artifact}", "--output", "spdx-json={{ .Document }}"]
+
+snapshot:
+  version_template: "{{ .Tag }}-snapshot-{{ .ShortCommit }}"
+
+changelog:
+  use: github
+  sort: asc
+  groups:
+    - title: Features
+      regexp: "^.*feat[(\\w)]*:+.*$"
+      order: 0
+    - title: Bug fixes
+      regexp: "^.*fix[(\\w)]*:+.*$"
+      order: 1
+    - title: Performance
+      regexp: "^.*perf[(\\w)]*:+.*$"
+      order: 2
+    - title: Documentation
+      regexp: "^.*docs[(\\w)]*:+.*$"
+      order: 3
+    - title: Other
+      order: 999
+  filters:
+    exclude:
+      - "^chore\\(deps\\):"
+      - "^chore\\(ci\\):"
+      - "^test:"
+      - "^ci:"
+      - "^Merge pull request"
+
+homebrew_casks:
+  - name: plexara-agents
+    ids: [default]
+    binaries: [ask]
+    repository:
+      owner: plexara
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    commit_author:
+      name: plexara-bot
+      email: support@plexara.io
+    commit_msg_template: "chore(formula): bump {{ .ProjectName }} to {{ .Tag }}"
+    directory: Casks
+    homepage: "https://github.com/plexara/plexara-agents"
+    description: "Local-first MCP-driven AI agents for Go"
+    license: Apache-2.0
+    skip_upload: auto
+
+release:
+  github:
+    owner: plexara
+    name: plexara-agents
+  draft: false
+  prerelease: auto
+  mode: replace
+  header: |
+    ## plexara-agents {{ .Tag }}
+
+    See `CHANGELOG.md` for the full list of changes.
+
+    ### Verifying artifacts
+
+    Every archive ships with a Sigstore-signed `_checksums.txt` and accompanying
+    `.pem` certificate, plus CycloneDX and SPDX SBOMs. SLSA build provenance is
+    available via `gh attestation verify`. Verification commands are documented
+    in `SECURITY.md`.
+  footer: |
+    Released by GoReleaser.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,110 @@
+# CI and Release Pipeline
+
+Operator's runbook for the GitHub Actions workflows under `.github/workflows/` and the GoReleaser configuration at `.goreleaser.yaml`.
+
+## Workflow inventory
+
+| Workflow | Trigger | Purpose |
+| --- | --- | --- |
+| `ci.yml` | PR + push to `main` | Build matrix, lint, test, coverage upload to Codecov |
+| `security.yml` | PR + push + weekly cron | gosec, govulncheck, Semgrep, Trivy fs scan |
+| `codeql.yml` | PR + push + weekly cron | GitHub CodeQL with `security-extended` + `security-and-quality` |
+| `scorecard.yml` | push to `main` + weekly cron + branch protection rule | OpenSSF Scorecard |
+| `dependency-review.yml` | PR | Block PRs that introduce vulnerable or non-permissive deps |
+| `pr-title.yml` | PR opened/edited/sync | Conventional Commits PR title check |
+| `fuzz.yml` | nightly cron + manual | Extended fuzz cycles, one matrix entry per `Fuzz*` target |
+| `release.yml` | tag `v*.*.*` | GoReleaser, cosign keyless signing, SBOMs, SLSA build provenance |
+
+## Required and optional secrets
+
+| Secret | Required for | Notes |
+| --- | --- | --- |
+| `GITHUB_TOKEN` | every workflow | Provided by GitHub automatically. No action needed. |
+| `CODECOV_TOKEN` | `ci.yml` (coverage upload) | Required. Obtain from <https://app.codecov.io>. |
+| `SCORECARD_READ_TOKEN` | `scorecard.yml` (Branch-Protection check only) | Optional. Without it, the Branch-Protection check returns `?` but every other check still runs. To populate: GitHub → Settings → Developer settings → Personal access tokens → Fine-grained → tokens scoped to this repo with **Administration: Read** + **Metadata: Read**. |
+| `HOMEBREW_TAP_GITHUB_TOKEN` | `release.yml` (Homebrew formula publish) | Optional. Without it, GoReleaser's `brews` step skips upload (`skip_upload: auto`). To populate: fine-grained PAT scoped to `plexara/homebrew-tap` with **Contents: Write** + **Metadata: Read**. |
+
+To inspect or update repository secrets, run:
+
+```sh
+gh secret list --repo plexara/plexara-agents
+gh secret set CODECOV_TOKEN --repo plexara/plexara-agents
+```
+
+## Action pinning
+
+Every third-party action is pinned to a full commit SHA with the human-readable version as a trailing comment, per spec §14.10. Example:
+
+```yaml
+- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+```
+
+Dependabot (`.github/dependabot.yml`) updates the SHAs weekly. **Reviewers must verify that the new SHA points at the same release the trailing comment claims.** OpenSSF Scorecard's `Pinned-Dependencies` check enforces this; missing pins fail Scorecard.
+
+## Coverage gates
+
+`.github/codecov.yml` configures:
+
+- `core/` target: 80% statement coverage, 1pp threshold, `if_ci_failed: error`
+- `cmd/`, `examples/`, `docs/`, test files, and mocks excluded from the gate
+
+Per spec §14.3: `cmd/...` and `examples/...` are exercised in tests but not gated; they exist as worked examples and integration scaffolding.
+
+## Empty source tree handling
+
+Until phase 3 (#4) lands the first Go source file, every CI workflow detects this and skips lint/test/build steps with an explanatory log message. The `lint` job still runs `go mod verify`, `go mod tidy -diff`, and `golangci-lint config verify` even on the empty tree. Once Go source lands, the detection step automatically activates the rest.
+
+## Release process
+
+1. **Cut a tag.** Tags must follow strict SemVer: `vX.Y.Z` for releases, optional pre-release suffixes (`-alpha`, `-beta`, `-rc.N`).
+   ```sh
+   git tag -s v0.1.0 -m "v0.1.0"
+   git push origin v0.1.0
+   ```
+2. **Tag push triggers `release.yml`**, which:
+   - Runs GoReleaser with cross-compile matrix (`darwin/{amd64,arm64}`, `linux/{amd64,arm64}`, `windows/amd64`).
+   - Generates CycloneDX and SPDX SBOMs per archive via Syft.
+   - Signs the checksums file with Cosign keyless (Sigstore OIDC) — produces `_checksums.txt.sig` and `_checksums.txt.pem`.
+   - Generates SLSA v1 build provenance for every archive and SBOM via `actions/attest-build-provenance`. Verifiable with `gh attestation verify`.
+   - Optionally publishes a Homebrew formula to `plexara/homebrew-tap` if `HOMEBREW_TAP_GITHUB_TOKEN` is set.
+3. **Verifying artifacts** (documented in `SECURITY.md`):
+   ```sh
+   # Cosign-verify the checksums file
+   cosign verify-blob \
+     --certificate-identity 'https://github.com/plexara/plexara-agents/.github/workflows/release.yml@refs/tags/v0.1.0' \
+     --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+     --certificate plexara-agents_v0.1.0_checksums.txt.pem \
+     --signature   plexara-agents_v0.1.0_checksums.txt.sig \
+     plexara-agents_v0.1.0_checksums.txt
+
+   # Verify SLSA provenance
+   gh attestation verify plexara-agents_v0.1.0_Linux_x86_64.tar.gz \
+     --owner plexara
+   ```
+
+## Branch protection (manual setup)
+
+Branch protection cannot be configured via these workflows. After the first green run on `main`, configure under GitHub → Settings → Branches → main:
+
+- Require pull request before merging (1 approving review, dismiss stale approvals on new commits, require code-owner review on owned paths).
+- Require status checks to pass before merging:
+  - `ci pass`
+  - `lint`
+  - `analyze go` (CodeQL)
+  - `govulncheck`
+  - `gosec`
+  - `semgrep`
+  - `trivy fs`
+  - `review` (dependency-review)
+  - `conventional commit` (pr-title)
+- Require linear history (squash or rebase, no merge commits).
+- Require signed commits.
+- Block force pushes.
+- Allow Dependabot to auto-merge PRs that pass all checks.
+
+## Troubleshooting
+
+- **Codecov upload fails with `Token Required`**: confirm `CODECOV_TOKEN` is set on the repo (`gh secret list`).
+- **Scorecard "Branch-Protection" returns `?`**: this is expected without `SCORECARD_READ_TOKEN`. Add the secret if you want full Scorecard coverage.
+- **`pr-title` fails with "subject must start with alphanumeric"**: PR title is missing the conventional-commits subject (e.g. `feat(core/loop): ` with nothing after the colon). Fix the title.
+- **Release fails on `brews` step**: `HOMEBREW_TAP_GITHUB_TOKEN` is unset and `skip_upload: auto` is supposed to skip. If failing anyway, inspect GoReleaser logs — most often the tap repo doesn't exist or the token lacks `Contents: Write` on it.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -52,7 +52,13 @@ Per spec §14.3: `cmd/...` and `examples/...` are exercised in tests but not gat
 
 ## Empty source tree handling
 
-Until phase 3 (#4) lands the first Go source file, every CI workflow detects this and skips lint/test/build steps with an explanatory log message. The `lint` job still runs `go mod verify`, `go mod tidy -diff`, and `golangci-lint config verify` even on the empty tree. Once Go source lands, the detection step automatically activates the rest.
+Until phase 3 (#4) lands the first Go source file, every CI workflow detects this and skips Go-source-dependent steps with an explanatory log message. The `lint` job still runs `go mod verify`, `go mod tidy -diff`, and `golangci-lint config verify` even on the empty tree (these don't need Go source).
+
+Steps that require Go source and are gated behind the detect job include: `gofmt`, `go vet`, `golangci-lint run`, `go test`, `go build`, CodeQL analyze, `gosec`, `semgrep`, and `govulncheck` (which exits 1 with "no packages matched" on an empty tree). Trivy scans the filesystem and runs unconditionally.
+
+Once Go source lands, the detect step's `has-source` output flips to `true` and the rest of the pipeline activates without any workflow change.
+
+**Branch protection note**: do not enable required status checks for source-dependent jobs (`govulncheck`, `gosec`, `semgrep`, CodeQL `analyze go`, `lint` if you've added stricter sub-steps) until *after* phase 3 lands. Skipped jobs do not satisfy a required status check. The `ci pass` aggregator and the always-running checks (`review`, `conventional commit`, `trivy fs`) are safe to require immediately.
 
 ## Release process
 


### PR DESCRIPTION
Closes #3. Part of #1 (project bootstrap, v0.1).

This is **phase 2 of 7** in the v0.1 bootstrap. It lands the entire CI / security / release pipeline before any Go source exists, so subsequent phases (#4 through #8) merge with all gates already enforced. The workflows are designed to tolerate the empty source tree and to activate automatically once phase 3 (#4) introduces the first `.go` file.

## Summary

- **8 GitHub Actions workflows** wired to the events called for in spec §14.2 (PR, push to `main`, weekly cron, tag push, branch-protection rule, manual dispatch).
- **Every third-party action SHA-pinned** with the human-readable version as a trailing comment, per spec §14.10. SHAs were fetched live from the GitHub API immediately before writing this PR.
- **GoReleaser configuration** with five-arch cross-compile, Cosign keyless signing, dual-format SBOMs (CycloneDX + SPDX), conventional-commits changelog, and an optional Homebrew tap publish step that skips silently when the tap token is absent.
- **Codecov configuration** with the spec's `core/` >80% gate, `cmd/`/`examples/`/`docs/`/tests excluded.
- **Operator runbook** at `docs/ci.md` covering workflow inventory, secret matrix, action-pinning policy, release process with verification commands, branch-protection setup, and troubleshooting.

## Phase mapping

| Phase | Issue | Branch | Status |
| --- | --- | --- | --- |
| 1. Repo skeleton & hygiene | #2 | `feat/bootstrap-skeleton` | merged (#9) |
| 2. CI & release pipeline (this PR) | #3 | `feat/bootstrap-ci` | open |
| 3. `core/event` + `core/provider` | #4 | `feat/bootstrap-event-provider` | next |
| 4. `core/mcp` + `core/session` | #5 | `feat/bootstrap-mcp-session` | |
| 5. `core/loop` + `core/router` + `core/approval` | #6 | `feat/bootstrap-loop-router-approval` | |
| 6. `cmd/ask` CLI | #7 | `feat/bootstrap-ask` | |
| 7. `examples/acme-revenue` + ADR + architecture doc | #8 | `feat/bootstrap-acme-example` | |

## Workflow inventory

### `ci.yml`
Pipeline: `detect` → (`lint` ‖ `test` ‖ `build`) → `ci-pass`.

- **`detect`** runs `find . -name '*.go' -not -path './.*' -not -path '*/testdata/*' -print -quit` and exposes a `has-source` output. Downstream jobs use `if: needs.detect.outputs.has-source == 'true'` to gate themselves until phase 3 lands.
- **`lint`** runs `go mod verify`, `go mod tidy -diff` (fails on drift), `gofmt -l`, `go vet`, `golangci-lint config verify`, `golangci-lint run`. The first three run unconditionally so config / module-graph regressions are caught immediately even with no source.
- **`test`** runs on `ubuntu-latest` and `macos-latest` with `go test -race -shuffle=on -count=1 -covermode=atomic -coverprofile=coverage.out ./...`. Coverage uploaded to Codecov from `ubuntu-latest` only with the `core` flag.
- **`build`** cross-compiles on `ubuntu-latest` across `darwin/{amd64,arm64}`, `linux/{amd64,arm64}`, `windows/amd64` with `CGO_ENABLED=0` and `-trimpath`.
- **`ci-pass`** is an aggregator that surfaces a single status check for branch protection. It tolerates `skipped` from `test`/`build` (empty-tree case) but not from `lint`.

### `security.yml`
Four parallel scanners. All findings flow through SARIF into the GitHub security tab.

- **`gosec`** with `-fmt sarif -no-fail`, uploaded via `github/codeql-action/upload-sarif`.
- **`govulncheck`** invoked through `go tool govulncheck ./...`; runs even on the empty tree to validate the module graph.
- **`semgrep`** runs in the official Semgrep container pinned to a multi-arch manifest digest, with `p/security-audit`, `p/secrets`, `p/golang`, and `p/owasp-top-ten` rulesets. SARIF upload via the CodeQL action.
- **`trivy`** filesystem scan; `exit-code: 0` so the SARIF gate (visible in the security tab) is the source of truth, not a forced PR failure.

### `codeql.yml`
Go analysis with the `security-extended` and `security-and-quality` query packs. Init/autobuild/analyze gated behind the same `detect` step so the workflow is a no-op until source exists.

### `scorecard.yml`
Weekly + push-to-main + `branch_protection_rule` triggers. Uses `${{ secrets.SCORECARD_READ_TOKEN || secrets.GITHUB_TOKEN }}` so the workflow runs without the optional fine-grained PAT (Branch-Protection check returns `?` until the PAT is added). Results published and uploaded as SARIF.

### `dependency-review.yml`
PR-only. `fail-on-severity: high`, `comment-summary-in-pr: on-failure`, license allowlist mirroring spec §14.7 (Apache-2.0, MIT, BSD-2/3-Clause, ISC, MPL-2.0, Unlicense, CC0-1.0, Zlib, BSD-2-Clause-Patent).

### `pr-title.yml`
Conventional Commits enforcement via `amannn/action-semantic-pull-request`. Allowed types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `perf`, `ci`, `build`, `revert`. Subject must start with an alphanumeric character.

### `fuzz.yml`
Nightly cron at 04:00 UTC plus `workflow_dispatch` with a configurable `duration` input (default `5m`). The `detect` job dynamically discovers `Fuzz*` targets via `go test -list 'Fuzz.*'` and emits a JSON matrix; the `fuzz` job fans out one runner per `(package, FuzzXxx)` pair. Failures upload `testdata/fuzz/` as a workflow artifact for triage. No-op when no targets exist.

### `release.yml`
Tag-driven (`v*.*.*`) with manual `workflow_dispatch` fallback. Single `release` job with the full provenance permission set (`contents: write`, `packages: write`, `id-token: write`, `attestations: write`).

Steps: harden-runner → checkout (`fetch-depth: 0`) → setup-go → install Cosign → install Syft → GoReleaser (`~> v2`, `release --clean`) → `actions/attest-build-provenance` over `dist/*.{tar.gz,zip,sbom.*}` → SBOM upload as workflow artifact.

The provenance step produces SLSA v1 in-toto attestations signed via Sigstore (keyless OIDC), verifiable with `gh attestation verify`.

## `.goreleaser.yaml`

- `homebrew_casks` (post-`brews`-deprecation) with `binaries: [ask]` (post-`binary`-deprecation), pushing to `plexara/homebrew-tap` under `Casks/`. `skip_upload: auto` so an absent `HOMEBREW_TAP_GITHUB_TOKEN` doesn't fail the release.
- 5-arch cross-compile (`darwin/{amd64,arm64}`, `linux/{amd64,arm64}`, `windows/amd64`) with `CGO_ENABLED=0`, `-trimpath`, `-s -w`, and `-X main.{version,commit,date,builtBy}` ldflags.
- `tar.gz` archives (`zip` for Windows) carrying `LICENSE`, `README.md`, `SECURITY.md`.
- `cosign sign-blob` over the SHA-256 checksums file with `--yes` (CI-safe; OIDC issuer is `token.actions.githubusercontent.com`).
- Dual-format SBOMs per archive: CycloneDX + SPDX, both via Syft.
- Conventional Commits changelog with grouped sections (Features / Bug fixes / Performance / Documentation / Other) and noisy categories (`chore(deps):`, `chore(ci):`, `test:`, `ci:`, merge commits) filtered out.

## `.github/codecov.yml`

- `coverage.range: 70...95`, `precision: 2`, `round: down`.
- `core` flag scoped to `core/` paths only, gated at 80% target with 1pp threshold on both `project` and `patch` checks. `if_ci_failed: error` so a CI failure also fails the coverage check.
- `cmd/`, `examples/`, `docs/`, `**/testdata/**`, `**/*_test.go`, and `**/mocks/**` are ignored.
- Comment layout: `reach,diff,flags,files,footer`.

## `docs/ci.md`

Single source of truth for operating the pipeline. Sections:

- Workflow inventory table (trigger × purpose).
- Secrets matrix with exact names, criticality, and how to obtain each PAT (fine-grained scoping for the optional ones).
- Action-pinning policy with example syntax and Dependabot's role.
- Coverage gate explanation tying the codecov.yml back to spec §14.3.
- Empty source-tree handling explanation.
- Release process: tag → workflow → artifact verification commands (cosign + `gh attestation verify`).
- Branch-protection setup checklist with the **exact required-status-check names** (`ci pass`, `lint`, `analyze go`, `govulncheck`, `gosec`, `semgrep`, `trivy fs`, `review`, `conventional commit`).
- Troubleshooting for the most common failure modes.

## Hard requirements verified

- `actionlint -color` over all 8 workflows → exit 0
- `goreleaser check` → 1 configuration file(s) validated, no deprecations
- `go tool golangci-lint config verify` → exit 0
- All 10 YAML files parse cleanly via `python3 -c yaml.safe_load`
- 16 distinct third-party actions SHA-pinned with `# vX.Y.Z` trailing comments

## Empty source-tree handling

Until phase 3 (#4) lands the first Go source file:

- `ci-pass` aggregator returns success.
- `go mod verify`, `go mod tidy -diff`, `golangci-lint config verify`, and `govulncheck` run unconditionally and stay green.
- All other steps (lint, vet, test, build, CodeQL, gosec, Semgrep) skip themselves with a log message via the `detect` job's `has-source` output.

The first time `core/event/event.go` (or any other `.go` file) lands, the `detect` job flips and the rest of the pipeline activates without any workflow change.

## Out of scope (deferred or manual)

- **Branch protection rules** on `main`. Cannot be configured in workflow YAML; requires manual setup under repo Settings. `docs/ci.md` lists the exact required-status-check names and ancillary toggles.
- **Self-hosted integration runner**. Phase 3+ may revisit if the integration test suite outgrows ubuntu-latest, but spec §14.3 explicitly defers integration tests behind a build tag and runner.
- **Container image publishing** to `ghcr.io`. Spec §14.8 says "added when the project starts publishing images" — not v0.1.

## Test plan

- [ ] Push triggers `ci.yml`. `detect` job sets `has-source=false`. `lint` runs (`go mod verify`, `go mod tidy -diff`, `golangci-lint config verify`) and passes. `test` and `build` jobs skip with the empty-tree message. `ci-pass` aggregator is green.
- [ ] `security.yml` runs. `govulncheck` passes. `gosec`, `semgrep`, and Trivy gate themselves out / produce empty SARIF. `trivy fs` runs on the source tree and reports any container/IaC findings (none expected).
- [ ] `codeql.yml` runs. `analyze go` skips with empty-tree message; check stays green.
- [ ] `dependency-review.yml` runs on this PR. Confirms allowlisted licenses, no high-severity vulns introduced.
- [ ] `pr-title.yml` validates this PR's title against the Conventional Commits spec (`ci(workflows): ...`).
- [ ] `scorecard.yml` runs on push to main after merge; confirm it shows up in the security tab.
- [ ] After merge, set `HOMEBREW_TAP_GITHUB_TOKEN` (optional) and `SCORECARD_READ_TOKEN` (optional). Configure branch protection per `docs/ci.md`.
- [ ] Phase 3 (#4) lands the first `.go` file; CI activates the gated steps automatically.